### PR TITLE
Add older release notes going back to 14.04

### DIFF
--- a/doc/source/releases.rst
+++ b/doc/source/releases.rst
@@ -2,6 +2,19 @@
 Release Notes
 =============
 
+Latest Release Notes
+ * `16.10 release <1610.html>`__
+
+Older release notes
+ * `16.07 release <https://wiki.ubuntu.com/OpenStack/OpenStackCharms/ReleaseNotes1607>`__
+ * `16.04 release <https://wiki.ubuntu.com/OpenStack/OpenStackCharms/ReleaseNotes1604>`__
+ * `16.01 release <https://wiki.ubuntu.com/OpenStack/OpenStackCharms/ReleaseNotes1601>`__
+ * `15.10 release <https://wiki.ubuntu.com/OpenStack/OpenStackCharms/ReleaseNotes1510>`__
+ * `15.07 release <https://wiki.ubuntu.com/OpenStack/OpenStackCharms/ReleaseNotes1507>`__
+ * `15.04 release <https://wiki.ubuntu.com/OpenStack/OpenStackCharms/ReleaseNotes1504>`__
+ * `15.01 release <https://wiki.ubuntu.com/OpenStack/OpenStackCharms/ReleaseNotes1501>`__
+ * `14.10 release <https://wiki.ubuntu.com/UtopicUnicorn/ReleaseNotes/OpenStackCharms>`__
+ * `14.04 release <https://wiki.ubuntu.com/TrustyTahr/ReleaseNotes/OpenStackCharms>`__
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
also adds a direct link to latest charm's release notes.