### PR TITLE
on bionic lxd is already present

### DIFF
--- a/doc/source/openstack-on-lxd.rst
+++ b/doc/source/openstack-on-lxd.rst
@@ -24,7 +24,6 @@ Ubuntu 18.04 (Bionic) is the current LTS release and should be used for this pro
 
 .. code:: bash
 
-    sudo snap install lxd
     sudo snap install juju --classic
 
     sudo apt install zfsutils-linux squid-deb-proxy bridge-utils \


### PR DESCRIPTION
On bionic lxd is already present, installing it via snap will create
two instances of lxd running which will make troubles during the
process.

Signed-off-by: Sahid Orentino Ferdjaoui <sahid.ferdjaoui@canonical.com>